### PR TITLE
deleteAll method added for clear the table of entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This plugin add some vuex actions to load and persist data in an IndexedDB
 | $create | Like VuexORM `insertOrUpdate`, but also persist data to IndexedDB |
 | $update | Update records using VuexORM `update` or `insertOrUpdate` then persist changes to IndexedDB |
 | $delete | Like VuexORM `delete`, but also remove data from IndexedDB |
+| $deleteAll | Like VuexORM `deleteAll`, but also delete all data from IndexedDB |
 
 ## Example Usage
 
@@ -128,7 +129,8 @@ These are options you can pass when calling VuexORM.use()
     $fetch: '$fetch',
     $create: '$create',
     $update: '$update',
-    $delete: '$delete'
+    $delete: '$delete',
+    $deleteAll: '$deleteAll'
   }
 }
 ```
@@ -159,7 +161,8 @@ VuexORM.use(VuexORMLocalForage, {
     $fetch: '$fetchFromLocal',
     $create: '$createLocally',
     $update: '$updateLocally',
-    $delete: '$deleteFromLocal'
+    $delete: '$deleteFromLocal',
+    $deleteAll: '$deleteAllFromLocal'
   }
 })
 ```

--- a/src/actions/DestroyAll.js
+++ b/src/actions/DestroyAll.js
@@ -1,0 +1,20 @@
+import Action from './Action';
+import Context from '../common/context';
+
+export default class DestroyAll extends Action {
+  /**
+   * Is Called after new model deletion from the store
+   *
+   * @param {object} record
+   * @param {string} entityName
+   */
+  static async call({ state, dispatch }) {
+    return dispatch('deleteAll').then(async (result) => {
+      const context = Context.getInstance();
+      const model = context.getModelFromState(state);
+      model.$localStore.clear();
+
+      return result;
+    });
+  }
+}

--- a/src/support/interfaces.js
+++ b/src/support/interfaces.js
@@ -28,6 +28,7 @@ export const VuexOrmPluginConfig = {
     $create: '$create',
     $update: '$update',
     $delete: '$delete',
+    $deleteAll: '$deleteAll',
   },
 
   /**

--- a/src/vuex-orm-localforage.js
+++ b/src/vuex-orm-localforage.js
@@ -5,6 +5,7 @@ import Fetch from './actions/Fetch';
 import Persist from './actions/Persist';
 import Get from './actions/Get';
 import Destroy from './actions/Destroy';
+import DestroyAll from './actions/DestroyAll';
 
 export default class VuexOrmLocalForage {
   /**
@@ -30,6 +31,7 @@ export default class VuexOrmLocalForage {
     context.components.Actions[actions.$create] = Persist.create.bind(Persist);
     context.components.Actions[actions.$update] = Persist.update.bind(Persist);
     context.components.Actions[actions.$delete] = Destroy.call.bind(Destroy);
+    context.components.Actions[actions.$deleteAll] = DestroyAll.call.bind(DestroyAll);
   }
 
   /**
@@ -66,6 +68,10 @@ export default class VuexOrmLocalForage {
 
     context.components.Model[actions.$delete] = function deleteFromLocalStore(payload = {}) {
       return this.dispatch(actions.$delete, payload);
+    };
+
+    context.components.Model[actions.$deleteAll] = function clearLocalStore() {
+      return this.dispatch(actions.$deleteAll);
     };
   }
 }


### PR DESCRIPTION
For some reason, I need to clear entity table before insert data to table. So I just added `$deleteAll` method for clear table. Example for usage;

```javascript
import Todo from './store/models/Todo'

await Todo.$deleteAll()
Todo.$create({
  data: [
    { title: 'Todo 1' },
    { title: 'Todo 2' }
  ]
})
```